### PR TITLE
Debug Fixes

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -33,7 +33,8 @@ var webpackConfig = merge(baseWebpackConfig, {
     }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
-        warnings: false
+        warnings: false,
+        drop_console: true
       },
       mangle: {
         except: [ 'Array', 'BigInteger', 'Boolean', 'ECPair', 'Function', 'Number', 'Point' ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Peng Zhong <peng@nylira.com>",
   "private": true,
   "scripts": {
-    "dev": "COSMOS_BASE_URL=https://cosmos.interblock.io node build/dev-server.js",
+    "dev": "COSMOS_BASE_URL=https://fundraiser.cosmos.network node build/dev-server.js",
     "prod": "node build/prod-server.js",
     "build": "node build/build.js",
     "build-dev": "node build/build-dev.js",

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@
       :notifications="notifications">
     </notifications>
     <modal-unsupported></modal-unsupported>
+    <debug v-if="debugActive"></debug>
   </div>
 </template>
 
@@ -21,6 +22,7 @@ import Modal from './components/Modal'
 import ModalUnsupported from './components/ModalUnsupported'
 import ModalLoading from './components/ModalLoading'
 import Notifications from '@nylira/vue-notifications'
+import Debug from './components/Debug'
 import store from './store/index.js'
 import { mapGetters } from 'vuex'
 
@@ -34,9 +36,13 @@ export default {
     Modal,
     ModalUnsupported,
     ModalLoading,
-    Notifications
+    Notifications,
+    Debug
   },
   computed: {
+    debugActive () {
+      return process.env.NODE_ENV === 'development'
+    },
     ...mapGetters(['notifications'])
   },
   head: {

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -3,20 +3,21 @@
     <header><strong>DEBUG</strong> - Change Fundraiser State</header>
     <section>
       <main>
-        <btn-group>
-          <btn
-            @click.native="reset" :class="resetCssClass"
-            icon="refresh" value="Reset"></btn>
-          <btn
-            @click.native="start" :class="startCssClass"
-            icon="play" value="Start"></btn>
-          <btn
-            @click.native="cap" :class="capCssClass"
-            icon="eye" value="Cap"></btn>
-          <btn
-            @click.native="end" :class="endCssClass"
-            icon="stop" value="End"></btn>
-        </btn-group>
+        <select v-on:change="setTime">
+          <option>Before Start</option>
+          <option>After Start</option>
+          <option>After Hidden Cap Period</option>
+          <option>After End</option>
+        </select>
+      </main>
+    </section>
+    <section>
+      <header>ETH contract isActive</header>
+      <main>
+        <select>
+          <option>0</option>
+          <option>1</option>
+        </select>
       </main>
     </section>
   </div>
@@ -33,32 +34,12 @@ export default {
     BtnGroup
   },
   computed: {
-    resetCssClass () {
-      if (this.debug.status === 0) return 'ni-btn-active'
-    },
-    startCssClass () {
-      if (this.debug.status === 1) return 'ni-btn-active'
-    },
-    capCssClass () {
-      if (this.debug.status === 2) return 'ni-btn-active'
-    },
-    endCssClass () {
-      if (this.debug.status === 3) return 'ni-btn-active'
-    },
     ...mapGetters(['debug'])
   },
   methods: {
-    reset () {
-      this.$store.commit('setDebugFundraiserStatus', 0)
-    },
-    start () {
-      this.$store.commit('setDebugFundraiserStatus', 1)
-    },
-    cap () {
-      this.$store.commit('setDebugFundraiserStatus', 2)
-    },
-    end () {
-      this.$store.commit('setDebugFundraiserStatus', 3)
+    setTime (e) {
+      let selection = e.target.selectedIndex
+      this.$store.commit('setDebugFundraiserTime', selection)
     }
   }
 }
@@ -74,8 +55,8 @@ bc = txt
   bottom 0
   left 0
   background hsla(0,0,0,0.75)
-  width 100vw
-  max-width 30rem
+  width 70vw
+  max-width 14rem
   shadow()
   color #fff
 

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -5,9 +5,10 @@
       <header>Change Fundraiser State</header>
       <main>
         <btn-group>
-          <btn @click.native="reset" value="Reset FR"></btn>
-          <btn @click.native="start" value="Start FR"></btn>
-          <btn @click.native="end" value="End FR"></btn>
+          <btn @click.native="reset" icon="refresh" value="Reset"></btn>
+          <btn @click.native="start" icon="play" value="Start"></btn>
+          <btn @click.native="showCap" icon="eye" value="Cap"></btn>
+          <btn @click.native="end" icon="stop" value="End"></btn>
         </btn-group>
       </main>
     </section>
@@ -15,6 +16,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import Btn from '@nylira/vue-button'
 import BtnGroup from './BtnGroup'
 export default {
@@ -23,15 +25,21 @@ export default {
     Btn,
     BtnGroup
   },
+  computed: {
+    ...mapGetters(['debug'])
+  },
   methods: {
     reset () {
-      this.$store.commit('setDebugFundraiserStatus', -1)
-    },
-    start () {
       this.$store.commit('setDebugFundraiserStatus', 0)
     },
-    end () {
+    start () {
       this.$store.commit('setDebugFundraiserStatus', 1)
+    },
+    showCap () {
+      this.$store.commit('setDebugFundraiserStatus', 2)
+    },
+    end () {
+      this.$store.commit('setDebugFundraiserStatus', 3)
     }
   }
 }
@@ -56,15 +64,17 @@ bc = txt
     border-bottom 1px solid bc
     text-transform uppercase
     font-weight bold
-    padding 0 1rem
+    padding 0 0.5rem
     line-height 1.5rem
     font-size 0.75rem
   > section
-    padding 0.5rem 1rem
+    padding 0.5rem
     > header
       font-size 0.875rem
       margin-bottom 0.5rem
     > main
       display flex
       flex-flow column nowrap
+      .ni-btn-group:last-of-type
+        margin-bottom 0
 </style>

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -25,13 +25,13 @@ export default {
   },
   methods: {
     reset () {
-      console.log('resetting fundraiser')
+      this.$store.commit('setDebugFundraiserStatus', -1)
     },
     start () {
-      console.log('starting fundraiser')
+      this.$store.commit('setDebugFundraiserStatus', 0)
     },
     end () {
-      console.log('ending fundraiser')
+      this.$store.commit('setDebugFundraiserStatus', 1)
     }
   }
 }

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -75,7 +75,7 @@ bc = txt
   left 0
   background hsla(0,0,0,0.75)
   width 100vw
-  max-width 40rem
+  max-width 30rem
   shadow()
   color #fff
 
@@ -91,8 +91,19 @@ bc = txt
       flex-flow column nowrap
       .ni-btn-group:last-of-type
         margin-bottom 0
+      .ni-btn
+        font-size 0.75rem
       .ni-btn-active .ni-btn
         background link
         border 1px solid lighten(link, 25%)
         color c-app-fg
+
+@media screen and (min-width: 360px)
+  #debug > section > main .ni-btn
+    font-size 1rem
+@media screen and (min-width: 768px)
+  #debug > header
+    padding 0 1rem
+  #debug > section
+    padding 1rem
 </style>

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -45,9 +45,9 @@ export default {
       let { commit, dispatch } = this.$store
       let selection = e.target.selectedIndex
       if (selection === 0) {
-        commit('setDebugStartDate', Date.now() + 30e3)
+        commit('setDebugStartDate', Date.now() + 10e3)
       } else if (selection === 1) {
-        commit('setDebugStartDate', Date.now())
+        commit('setDebugStartDate', Date.now() - 60 * 60e3)
       } else if (selection === 2) {
         commit('setDebugStartDate', Date.now() - 24 * 60 * 60e3)
       } else if (selection === 3) {

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -1,0 +1,70 @@
+<template>
+  <div id="debug">
+    <header>DEBUG</header>
+    <section>
+      <header>Change Fundraiser State</header>
+      <main>
+        <btn-group>
+          <btn @click.native="reset" value="Reset FR"></btn>
+          <btn @click.native="start" value="Start FR"></btn>
+          <btn @click.native="end" value="End FR"></btn>
+        </btn-group>
+      </main>
+    </section>
+  </div>
+</template>
+
+<script>
+import Btn from '@nylira/vue-button'
+import BtnGroup from './BtnGroup'
+export default {
+  name: 'debug',
+  components: {
+    Btn,
+    BtnGroup
+  },
+  methods: {
+    reset () {
+      console.log('resetting fundraiser')
+    },
+    start () {
+      console.log('starting fundraiser')
+    },
+    end () {
+      console.log('ending fundraiser')
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@import '../styles/variables.styl'
+
+bc = txt
+
+#debug
+  position fixed
+  bottom 0
+  left 0
+  background hsla(0,0,0,0.75)
+  width 100vw
+  max-width 40rem
+  shadow()
+  color #fff
+
+  > header
+    border-bottom 1px solid bc
+    text-transform uppercase
+    font-weight bold
+    padding 0 1rem
+    line-height 1.5rem
+    font-size 0.75rem
+  > section
+    padding 0.5rem 1rem
+    > header
+      font-size 0.875rem
+      margin-bottom 0.5rem
+    > main
+      display flex
+      flex-flow column nowrap
+</style>

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -5,10 +5,18 @@
       <header>Change Fundraiser State</header>
       <main>
         <btn-group>
-          <btn @click.native="reset" icon="refresh" value="Reset"></btn>
-          <btn @click.native="start" icon="play" value="Start"></btn>
-          <btn @click.native="showCap" icon="eye" value="Cap"></btn>
-          <btn @click.native="end" icon="stop" value="End"></btn>
+          <btn
+            @click.native="reset" :class="resetCssClass"
+            icon="refresh" value="Reset"></btn>
+          <btn
+            @click.native="start" :class="startCssClass"
+            icon="play" value="Start"></btn>
+          <btn
+            @click.native="cap" :class="capCssClass"
+            icon="eye" value="Cap"></btn>
+          <btn
+            @click.native="end" :class="endCssClass"
+            icon="stop" value="End"></btn>
         </btn-group>
       </main>
     </section>
@@ -26,6 +34,18 @@ export default {
     BtnGroup
   },
   computed: {
+    resetCssClass () {
+      if (this.debug.status === 0) return 'ni-btn-active'
+    },
+    startCssClass () {
+      if (this.debug.status === 1) return 'ni-btn-active'
+    },
+    capCssClass () {
+      if (this.debug.status === 2) return 'ni-btn-active'
+    },
+    endCssClass () {
+      if (this.debug.status === 3) return 'ni-btn-active'
+    },
     ...mapGetters(['debug'])
   },
   methods: {
@@ -35,7 +55,7 @@ export default {
     start () {
       this.$store.commit('setDebugFundraiserStatus', 1)
     },
-    showCap () {
+    cap () {
       this.$store.commit('setDebugFundraiserStatus', 2)
     },
     end () {
@@ -77,4 +97,8 @@ bc = txt
       flex-flow column nowrap
       .ni-btn-group:last-of-type
         margin-bottom 0
+      .ni-btn-active .ni-btn
+        background link
+        border 1px solid lighten(link, 25%)
+        color c-app-fg
 </style>

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -1,8 +1,7 @@
 <template>
   <div id="debug">
-    <header>DEBUG</header>
+    <header><strong>DEBUG</strong> - Change Fundraiser State</header>
     <section>
-      <header>Change Fundraiser State</header>
       <main>
         <btn-group>
           <btn
@@ -82,16 +81,11 @@ bc = txt
 
   > header
     border-bottom 1px solid bc
-    text-transform uppercase
-    font-weight bold
     padding 0 0.5rem
     line-height 1.5rem
     font-size 0.75rem
   > section
     padding 0.5rem
-    > header
-      font-size 0.875rem
-      margin-bottom 0.5rem
     > main
       display flex
       flex-flow column nowrap

--- a/src/components/Debug.vue
+++ b/src/components/Debug.vue
@@ -3,7 +3,14 @@
     <header><strong>DEBUG</strong> - Change Fundraiser State</header>
     <section>
       <main>
-        <select v-on:change="setTime">
+        <span>Debug Mode</span>
+        <input type="checkbox" v-on:change="setDebugEnabled" checked />
+      </main>
+    </section>
+    <section>
+      <header>Time</header>
+      <main>
+        <select id="debug-time-select"  v-on:change="setTime">
           <option>Before Start</option>
           <option>After Start</option>
           <option>After Hidden Cap Period</option>
@@ -14,10 +21,7 @@
     <section>
       <header>ETH contract isActive</header>
       <main>
-        <select>
-          <option>0</option>
-          <option>1</option>
-        </select>
+        <input id="debug-is-active-checkbox" type="checkbox" v-on:change="setIsActive" value="on" />
       </main>
     </section>
   </div>
@@ -38,9 +42,34 @@ export default {
   },
   methods: {
     setTime (e) {
+      let { commit, dispatch } = this.$store
       let selection = e.target.selectedIndex
-      this.$store.commit('setDebugFundraiserTime', selection)
+      if (selection === 0) {
+        commit('setDebugStartDate', Date.now() + 30e3)
+      } else if (selection === 1) {
+        commit('setDebugStartDate', Date.now())
+      } else if (selection === 2) {
+        commit('setDebugStartDate', Date.now() - 24 * 60 * 60e3)
+      } else if (selection === 3) {
+        commit('setDebugStartDate', Date.now() - 15 * 24 * 60 * 60e3)
+      }
+      dispatch('checkTime')
+    },
+    setDebugEnabled (e) {
+      let enabled = e.target.checked
+      this.$store.commit('setDebugEnabled', enabled)
+      if (enabled) {
+        this.setIsActive({ target: document.getElementById('debug-is-active-checkbox') })
+        this.setTime({ target: document.getElementById('debug-time-select') })
+      }
+    },
+    setIsActive (e) {
+      let isActive = e.target.checked
+      this.$store.commit('setIsActive', isActive)
     }
+  },
+  mounted () {
+    this.setDebugEnabled({ target: { checked: true } })
   }
 }
 </script>
@@ -62,11 +91,11 @@ bc = txt
 
   > header
     border-bottom 1px solid bc
-    padding 0 0.5rem
+    padding 0 0.25rem
     line-height 1.5rem
     font-size 0.75rem
   > section
-    padding 0.5rem
+    padding 0.25rem
     > main
       display flex
       flex-flow column nowrap
@@ -78,13 +107,4 @@ bc = txt
         background link
         border 1px solid lighten(link, 25%)
         color c-app-fg
-
-@media screen and (min-width: 360px)
-  #debug > section > main .ni-btn
-    font-size 1rem
-@media screen and (min-width: 768px)
-  #debug > header
-    padding 0 1rem
-  #debug > section
-    padding 1rem
 </style>

--- a/src/components/ModuleStatistics.vue
+++ b/src/components/ModuleStatistics.vue
@@ -50,9 +50,9 @@ export default {
     capped () {
       let utcStart = moment.utc(this.config.START_DATETIME)
       let localStart = moment(utcStart).local()
-      let endHiddenCap = (localStart).add(this.config.CAP_START, 'hours')._d
-      let now = Math.trunc((new Date()).getTime() / 1000)
-      return endHiddenCap < now
+      let endHiddenCapStr = (localStart).add(this.config.CAP_START, 'hours')._d
+      let endHiddenCap = Math.floor(new Date(endHiddenCapStr).getTime() / 1000)
+      return endHiddenCap < this.now
     },
     pbLabel () {
       if (this.capped) {
@@ -90,8 +90,14 @@ export default {
   },
   data () {
     return {
-      num: num
+      num: num,
+      now: Math.floor(Date.now() / 1000)
     }
+  },
+  mounted () {
+    setInterval(() => {
+      this.now = Math.floor(Date.now() / 1000)
+    }, 1000)
   }
 }
 </script>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -6,11 +6,13 @@
         <time-remaining
           type="cap"
           :date="endHiddenDatetime"
-          :started="started">
+          :started="started"
+          :ended="ended">
         </time-remaining>
         <time-remaining
           :date="endDatetime"
-          :started="started">
+          :started="started"
+          :ended="ended">
         </time-remaining>
       </key-values>
     </div>
@@ -47,7 +49,7 @@ export default {
         return localStart
       }
     },
-    ...mapGetters(['config', 'started', 'fundraiserActive'])
+    ...mapGetters(['config', 'started', 'ended', 'fundraiserActive'])
   }
 }
 </script>

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -21,9 +21,9 @@ export default {
     capped () {
       let utcStart = moment.utc(this.config.START_DATETIME)
       let localStart = moment(utcStart).local()
-      let endHiddenCap = (localStart).add(this.config.CAP_START, 'hours')._d
-      let now = Math.trunc((new Date()).getTime() / 1000)
-      return endHiddenCap < now
+      let endHiddenCapStr = (localStart).add(this.config.CAP_START, 'hours')._d
+      let endHiddenCap = Math.floor(new Date(endHiddenCapStr).getTime() / 1000)
+      return endHiddenCap < this.now
     },
     percentageDonated () {
       return this.atomsClaimed / this.config.CAP_AMOUNT
@@ -40,8 +40,14 @@ export default {
   },
   data () {
     return {
-      num: num
+      num: num,
+      now: Math.floor(Date.now() / 1000)
     }
+  },
+  mounted () {
+    setInterval(() => {
+      this.now = Math.floor(Date.now() / 1000)
+    }, 1000)
   }
 }
 </script>

--- a/src/components/TimeRemaining.vue
+++ b/src/components/TimeRemaining.vue
@@ -1,5 +1,11 @@
 <template>
-  <key-value class="ni-time-remaining" :title="date" v-if="countingDown">
+  <key-value class="ni-time-remaining" :title="date" v-if="type !== 'cap' && (ended || (started && !countingDown))">
+    <div slot="value">
+      <i class="fa fa-hourglass-end"></i>
+    </div>
+    <div slot="key">fundraiser ended</div>
+  </key-value>
+  <key-value class="ni-time-remaining" :title="date" v-else-if="countingDown && !ended">
     <div slot="value">
       <template v-if="days > 0">{{ days }}d</template>
       <template v-if="hours > 0">{{ hours }}h</template>
@@ -8,18 +14,18 @@
     </div>
     <div slot="key">{{ label }}</div>
   </key-value>
+  <key-value class="ni-time-remaining" :title="date" v-else-if="!started && !countingDown">
+    <div slot="value">
+      Starting soon
+    </div>
+    <div slot="key">Please wait</div>
+  </key-value>
   <key-value class="ni-time-remaining" :title="date" v-else-if="type === 'cap'">
     <div slot="value">
       --
     </div>
     <div slot="key">hidden cap ended</div>
     {{ started }}
-  </key-value>
-  <key-value class="ni-time-remaining" :title="date" v-else>
-    <div slot="value">
-      <i class="fa fa-hourglass-end"></i>
-    </div>
-    <div slot="key">fundraise ended</div>
   </key-value>
 </template>
 
@@ -69,6 +75,6 @@ export default {
       this.now = Math.trunc((new Date()).getTime() / 1000)
     }, 1000)
   },
-  props: ['date', 'started', 'type']
+  props: ['date', 'started', 'ended', 'type']
 }
 </script>

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -19,3 +19,4 @@ export const progress = state => state.stats.progress
 export const balance = state => state.balance
 
 export const docs = state => state.docs
+export const debug = state => state.debug

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -15,7 +15,7 @@ const state = {
   PASSWORD_MIN: 8,
   PASSWORD_MAX: 512,
   CAP_START: 6,         // cap enforced X hours after START_DATETIME
-  CAP_AMOUNT: 10000000, // cap in $X USD
+  CAP_AMOUNT: 100000000, // cap in ATOM ($0.10 USD)
   ATOM: {
   },
   COINS: {

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -35,6 +35,13 @@ const state = {
   }
 }
 
+const mutations = {
+  setDebugStartDate (state, date) {
+    state.START_DATETIME = new Date(date).toISOString()
+  }
+}
+
 export default {
-  state
+  state,
+  mutations
 }

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -1,14 +1,14 @@
 const state = {
-  status: 0
+  time: 0
 }
 
 const mutations = {
-  setDebugFundraiserStatus (state, status) {
-    state.status = status
-    if (status === 0) console.log('resetting fundraiser')
-    if (status === 1) console.log('starting fundraiser')
-    if (status === 2) console.log('showing fundraiser cap')
-    if (status === 3) console.log('ending fundraiser')
+  setDebugFundraiserTime (state, time) {
+    state.time = time
+    if (time === 0) console.log('resetting fundraiser')
+    if (time === 1) console.log('starting fundraiser')
+    if (time === 2) console.log('showing fundraiser cap')
+    if (time === 3) console.log('ending fundraiser')
   }
 }
 

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -1,5 +1,5 @@
 const state = {
-  enabled: true
+  enabled: process.env.NODE_ENV === 'development'
 }
 
 const mutations = {

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -1,0 +1,17 @@
+const state = {
+  status: -1
+}
+
+const mutations = {
+  setDebugFundraiserStatus (state, status) {
+    state.status = status
+    if (status === -1) console.log('resetting fundraiser')
+    if (status === 0) console.log('starting fundraiser')
+    if (status === 1) console.log('ending fundraiser')
+  }
+}
+
+export default {
+  state,
+  mutations
+}

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -5,9 +5,10 @@ const state = {
 const mutations = {
   setDebugFundraiserStatus (state, status) {
     state.status = status
-    if (status === -1) console.log('resetting fundraiser')
-    if (status === 0) console.log('starting fundraiser')
-    if (status === 1) console.log('ending fundraiser')
+    if (status === 0) console.log('resetting fundraiser')
+    if (status === 1) console.log('starting fundraiser')
+    if (status === 2) console.log('showing fundraiser cap')
+    if (status === 3) console.log('ending fundraiser')
   }
 }
 

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -1,14 +1,10 @@
 const state = {
-  time: 0
+  enabled: true
 }
 
 const mutations = {
-  setDebugFundraiserTime (state, time) {
-    state.time = time
-    if (time === 0) console.log('resetting fundraiser')
-    if (time === 1) console.log('starting fundraiser')
-    if (time === 2) console.log('showing fundraiser cap')
-    if (time === 3) console.log('ending fundraiser')
+  setDebugEnabled (state, enabled) {
+    state.enabled = enabled
   }
 }
 

--- a/src/store/modules/debug.js
+++ b/src/store/modules/debug.js
@@ -1,5 +1,5 @@
 const state = {
-  status: -1
+  status: 0
 }
 
 const mutations = {

--- a/src/store/modules/stats.js
+++ b/src/store/modules/stats.js
@@ -3,7 +3,10 @@ import { bitcoin, ethereum } from 'cosmos-fundraiser'
 const state = {
   started: false,
   ended: false,
-  overlayMessage: 'The fundraiser has not started yet.',
+  pastStart: false,
+  pastEnd: false,
+  isActive: false,
+  overlayMessage: '',
   progress: {
     btcRaised: 0,
     btcTxCount: 0,
@@ -11,6 +14,16 @@ const state = {
     ethTxCount: 0,
     atomsClaimedBtc: 0,
     atomsClaimedEth: 0
+  }
+}
+
+function setStatus () {
+  state.started = state.isActive || state.pastStart
+  state.ended = (!state.isActive && state.pastStart) || state.pastEnd
+  if (state.ended) {
+    state.overlayMessage = 'The fundraiser has ended.'
+  } else {
+    state.overlayMessage = 'The fundraiser has not started yet.'
   }
 }
 
@@ -39,12 +52,17 @@ const mutations = {
   setAtomsClaimedEth (state, atomsClaimedEth) {
     state.progress.atomsClaimedEth = atomsClaimedEth
   },
-  setStarted (state, started) {
-    state.started = started
+  setPastStart (state, pastStart) {
+    state.pastStart = pastStart
+    setStatus()
   },
-  setEnded (state, ended) {
-    state.ended = ended
-    if (ended) state.overlayMessage = 'The fundraiser has ended.'
+  setPastEnd (state, pastEnd) {
+    state.pastEnd = pastEnd
+    setStatus()
+  },
+  setIsActive (state, isActive) {
+    state.isActive = isActive
+    setStatus()
   }
 }
 
@@ -97,6 +115,9 @@ const actions = {
     dispatch('fetchStats')
   },
   checkStatus ({ commit, rootState }) {
+    if (rootState.debug.enabled) {
+      return
+    }
     ethereum.fetchIsActive('', (err, res) => {
       if (err) {
         console.error(err.stack)
@@ -107,18 +128,23 @@ const actions = {
         return
       }
       let isActive = res === 1
-      let startTime = new Date(rootState.config.START_DATETIME).getTime()
-      let endTime = startTime + rootState.config.ENDS_AFTER * 24 * 60 * 60 * 1000
-      // can start up to 1 hour late
-      let pastStart = Date.now() > (startTime + 60 * 60 * 1000)
-      let pastEnd = Date.now() > (startTime + endTime)
-      commit('setStarted', isActive || pastStart)
-      commit('setEnded', (!isActive && pastStart) || pastEnd)
+      commit('setIsActive', isActive)
     })
   },
+  checkTime ({ commit, rootState }) {
+    let startTime = new Date(rootState.config.START_DATETIME).getTime()
+    let endTime = startTime + rootState.config.ENDS_AFTER * 24 * 60 * 60 * 1000
+    // can start up to 1 hour late
+    let pastStart = Date.now() > (startTime + 60 * 60 * 1000)
+    let pastEnd = Date.now() > (startTime + endTime)
+    commit('setPastStart', pastStart)
+    commit('setPastEnd', pastEnd)
+  },
   startStatusInterval ({ dispatch }) {
-    setInterval(() => dispatch('checkStatus'), 10e3) // poll every 10s
+    setInterval(() => dispatch('checkStatus'), 10e3) // poll eth/isActive every 10s
     dispatch('checkStatus')
+    setInterval(() => dispatch('checkTime'), 1e3) // poll clock every 10s
+    dispatch('checkTime')
   }
 }
 

--- a/src/store/modules/stats.js
+++ b/src/store/modules/stats.js
@@ -68,6 +68,7 @@ const mutations = {
 
 const actions = {
   fetchStats ({ commit }) {
+    if (!state.started) return
     bitcoin.fetchFundraiserStats((err, stats) => {
       console.log('ATOMS CLAIMED BTC', stats.amountClaimed)
       if (err) {


### PR DESCRIPTION
I added a debug menu to make it easier to test the various fundraiser stages (before start, after start, after hidden cap, after end), along with the `isActive` value from the ETH contract.

This helped fix various small UI-level bugs, the fixes are also in this PR.

Fixes:
- Fixed some time/isActive states. For example, when the start time has passed but `isActive` is not yet set, it now will show "Starting soon, please wait" rather than "The fundraiser has ended"
- The hidden cap ending would previously not update in the UI
- The cap was set in the config to 10,000,000, but should actually be denominated in ATOMs so this was really a $1M cap
- The small amount of test transactions we have made were displayed before the start of the fundraiser, which could be confusing (previously showed "1260 ATOMs claimed, the fundraiser has not started yet")